### PR TITLE
Remove broken link from resources.md

### DIFF
--- a/resources.md
+++ b/resources.md
@@ -10,9 +10,6 @@
 ## Other resources
 1. [CodeNewbie - #100DaysOfCode Slack Channel](https://codenewbie.typeform.com/to/uwsWlZ)
 
-## Tools
-1. [cntr](https://github.com/nsgonultas/cntr): A command line day counter to track your progress easily
-
 ## Books (both coding and non-coding)
 
 ### Non-Coding


### PR DESCRIPTION
I am recommending the removal of the following link as it does not seem to be working and a quick search did not turn any results for the project.

Text in question:

## Tools
1. [cntr](https://github.com/nsgonultas/cntr): A command line day counter to track your progress easily